### PR TITLE
fix: queue-state-mutation

### DIFF
--- a/addon/components/sequential-render.js
+++ b/addon/components/sequential-render.js
@@ -276,9 +276,10 @@ export default Component.extend({
   updateRenderStates() {
     set(this, 'isFullFilled', true);
 
-    run.next(() => {
+    let runNext = run.next(() => {
       this.reportRenderState();
     });
+    get(this, 'renderStates').scheduledCalls.pushObject(runNext);
   }
 });
 

--- a/addon/components/sequential-render.js
+++ b/addon/components/sequential-render.js
@@ -255,17 +255,19 @@ export default Component.extend({
       let {
         renderPriority,
         taskName,
-        quickRender
-      } = getProperties(this, 'renderPriority', 'taskName', 'quickRender');
+        quickRender,
+        renderStates
+      } = getProperties(this, 'renderPriority', 'taskName', 'quickRender', 'renderStates');
 
-      delete get(this, 'renderStates').scheduledCalls[taskName];
+      
+      renderStates.removeScheduledCall(taskName);
 
       if (get(this, 'renderCallback')) {
         get(this, 'renderCallback')(get(this, 'content'));
       }
 
       if (!quickRender) {
-        get(this, 'renderStates').removeFromQueueAndModifyRender(renderPriority, taskName);
+        renderStates.removeFromQueueAndModifyRender(renderPriority, taskName);
       }
 
       setProperties(this, {
@@ -281,7 +283,7 @@ export default Component.extend({
     let runNext = run.next(() => {
       this.reportRenderState();
     });
-    get(this, 'renderStates').scheduledCalls[get(this, 'taskName')] = runNext;
+    get(this, 'renderStates').addScheduledCall(get(this, 'taskName'), runNext);
   }
 });
 

--- a/addon/components/sequential-render.js
+++ b/addon/components/sequential-render.js
@@ -258,6 +258,8 @@ export default Component.extend({
         quickRender
       } = getProperties(this, 'renderPriority', 'taskName', 'quickRender');
 
+      delete get(this, 'renderStates').scheduledCalls[taskName];
+
       if (get(this, 'renderCallback')) {
         get(this, 'renderCallback')(get(this, 'content'));
       }
@@ -279,7 +281,7 @@ export default Component.extend({
     let runNext = run.next(() => {
       this.reportRenderState();
     });
-    get(this, 'renderStates').scheduledCalls.pushObject(runNext);
+    get(this, 'renderStates').scheduledCalls[get(this, 'taskName')] = runNext;
   }
 });
 

--- a/addon/services/render-states.js
+++ b/addon/services/render-states.js
@@ -25,7 +25,7 @@ import {
   RENDER_STATE_CHANGE_EVENT
 } from '../constants/render-states';
 import Evented from '@ember/object/evented';
-import { later } from '@ember/runloop';
+import { later, cancel } from '@ember/runloop';
 
 const { critical: CRITICAL_RENDER_STATE, secondary: MAX_RENDER_PRIORITY } = RENDER_PRIORITY;
 
@@ -48,7 +48,8 @@ export default Service.extend(Evented, {
     this._super(...arguments);
     setProperties(this, {
       renderQueue: {},
-      availablePriorities: A()
+      availablePriorities: A(),
+      scheduledCalls: A()
     })
   },
 
@@ -82,6 +83,9 @@ export default Service.extend(Evented, {
       // We need't trigger state change for reset. It should be handled through the context change.
       renderState: CRITICAL_RENDER_STATE 
     });
+    let scheduledCalls = get(this, 'scheduledCalls');
+    scheduledCalls.forEach(call => cancel(call));
+    set(this, 'scheduledCalls', A());
   },
   modifyRenderState(state) {
     let {

--- a/addon/services/render-states.js
+++ b/addon/services/render-states.js
@@ -49,11 +49,19 @@ export default Service.extend(Evented, {
     this._resetProperties();
   },
 
+  /**
+   * @private
+   * @function _resetProperties
+   * @description Resets all queues and states
+   */
   _resetProperties() {
     setProperties(this, {
       renderQueue: {},
       availablePriorities: A(),
-      scheduledCalls: {}
+      scheduledCalls: {},
+      maxRenderPriority: MAX_RENDER_PRIORITY,
+      // We need't trigger state change for reset. It should be handled through the context change.
+      renderState: CRITICAL_RENDER_STATE
     })
   },
 
@@ -83,11 +91,6 @@ export default Service.extend(Evented, {
     let scheduledCalls = get(this, 'scheduledCalls');
     Object.values(scheduledCalls).forEach(call => cancel(call));
     this._resetProperties();
-    setProperties(this, {
-      maxRenderPriority: MAX_RENDER_PRIORITY,
-      // We need't trigger state change for reset. It should be handled through the context change.
-      renderState: CRITICAL_RENDER_STATE 
-    });
   },
   modifyRenderState(state) {
     let {
@@ -107,6 +110,27 @@ export default Service.extend(Evented, {
     } else {
       this.modifyRenderState(state + 1);
     }
+  },
+
+  /**
+   * @function addScheduledCall
+   * @description Adds new entry to scheduledCalls property in {taskName: function(){}} format.
+   * @param {String} taskName - The name of the task to be added.
+   * @param {function} funtionReference - The scheduled function reference for the taskName.
+   */
+  addScheduledCall(taskName, funtionReference) {
+    let scheduledCalls = get(this, 'scheduledCalls');
+    scheduledCalls[taskName] = funtionReference;
+  },
+
+  /**
+   * @function removeScheduledCall
+   * @description Removes the entry from scheduledCalls property.
+   * @param {String} taskName - The name of the task to be removed
+   */
+  removeScheduledCall(taskName) {
+    let scheduledCalls = get(this, 'scheduledCalls');
+    delete scheduledCalls[taskName];
   },
 
   addToQueue(priority, taskName) {

--- a/addon/services/render-states.js
+++ b/addon/services/render-states.js
@@ -46,10 +46,14 @@ export default Service.extend(Evented, {
 
   init() {
     this._super(...arguments);
+    this._resetProperties();
+  },
+
+  _resetProperties() {
     setProperties(this, {
       renderQueue: {},
       availablePriorities: A(),
-      scheduledCalls: A()
+      scheduledCalls: {}
     })
   },
 
@@ -76,16 +80,14 @@ export default Service.extend(Evented, {
     @public
   */
   resetRenderState() {
+    let scheduledCalls = get(this, 'scheduledCalls');
+    Object.values(scheduledCalls).forEach(call => cancel(call));
+    this._resetProperties();
     setProperties(this, {
-      renderQueue: {},
       maxRenderPriority: MAX_RENDER_PRIORITY,
-      availablePriorities: A(),
       // We need't trigger state change for reset. It should be handled through the context change.
       renderState: CRITICAL_RENDER_STATE 
     });
-    let scheduledCalls = get(this, 'scheduledCalls');
-    scheduledCalls.forEach(call => cancel(call));
-    set(this, 'scheduledCalls', A());
   },
   modifyRenderState(state) {
     let {

--- a/tests/unit/services/render-states-test.js
+++ b/tests/unit/services/render-states-test.js
@@ -29,6 +29,19 @@ module('Unit | Service | render-states', function(hooks) {
     assert.equal(service.maxRenderPriority, 3, 'Test that the new max priority is updated');
   });
 
+  test('resetRenderState: Test that resetRenderState calls _resetProperties', function(assert) {
+    let service = this.owner.lookup('service:render-states');
+    const resetPropertiesSpy = sinon.spy(service, '_resetProperties');
+    setProperties(service, {
+      maxRenderPriority: 5,
+      scheduledCalls: {'task1': function testFn1(){}, 'task2': function testFn2(){}}
+    });
+    service.resetRenderState();
+    sinon.assert.callCount(resetPropertiesSpy, 1);
+    resetPropertiesSpy.restore();
+    assert.ok(true);
+  });
+
   test('resetRenderState: Test that all the states / queues are reset', function(assert) {
     let service = this.owner.lookup('service:render-states');
 
@@ -86,6 +99,25 @@ module('Unit | Service | render-states', function(hooks) {
     assert.notIncludes(service.renderQueue[0], 'uniqueP0Task2', 'Test P0 task removal');
     assert.ok(service.removeFromQueue(0, 'uniqueP0Task1'), 'Test returns true when queue is empty');
     assert.empty(service.renderQueue[0], 'Test all tasks are removed');
+  });
+
+  test('addScheduledCall: Test adding function calls to scheduleCalls', function(assert) {
+    let service = this.owner.lookup('service:render-states');
+    service.addScheduledCall('task1', function testFn1(){});
+    assert.includes(Object.keys(service.scheduledCalls)[0], 'task1', 'Test task1 added to scheduledCall');
+    service.addScheduledCall('task2', function testFn2(){});
+    assert.includes(Object.keys(service.scheduledCalls)[1], 'task2', 'Test task2 added to scheduledCall');
+    service.addScheduledCall('task3', function testFn3(){});
+    assert.includes(Object.keys(service.scheduledCalls)[2], 'task3', 'Test task3 added to scheduledCall');
+  });
+
+  test('removeScheduledCall: Test removing function calls to scheduleCalls', function(assert) {
+    let service = this.owner.lookup('service:render-states');
+    service.resetRenderState();
+    service.addScheduledCall('task1', function testFn1(){});
+    service.addScheduledCall('task2', function testFn2(){});
+    service.removeScheduledCall('task1');
+    assert.notOk((Object.keys(service.scheduledCalls)[0]).includes('task1'));
   });
 
   module('Test render state changes when items are removed from the queue', function() {

--- a/tests/unit/services/render-states-test.js
+++ b/tests/unit/services/render-states-test.js
@@ -36,7 +36,8 @@ module('Unit | Service | render-states', function(hooks) {
       maxRenderPriority: 5,
       renderState: 2,
       availablePriorities: [0, 2, 5],
-      renderQueue: { 0: [], 2: ['uniqueP2Task1'], 5: ['uniqueP5Task1'] }
+      renderQueue: { 0: [], 2: ['uniqueP2Task1'], 5: ['uniqueP5Task1'] },
+      scheduledCalls: [function testFn1(){}, function testFn2(){}]
     });
 
     service.resetRenderState();
@@ -44,6 +45,7 @@ module('Unit | Service | render-states', function(hooks) {
     assert.equal(service.maxRenderPriority, 1, 'Test that maxRenderPriority is reset');
     assert.empty(service.availablePriorities, 'Test that availablePriorities is empty');
     assert.equal(service.renderState, 0, 'Test that renderState is reset');
+    assert.empty(service.scheduledCalls, 'Test that scheduledCalls array is reset');
   });
 
   test('triggerRenderStateChange: Test that the event is fired on calling the function', function(assert) {

--- a/tests/unit/services/render-states-test.js
+++ b/tests/unit/services/render-states-test.js
@@ -37,7 +37,7 @@ module('Unit | Service | render-states', function(hooks) {
       renderState: 2,
       availablePriorities: [0, 2, 5],
       renderQueue: { 0: [], 2: ['uniqueP2Task1'], 5: ['uniqueP5Task1'] },
-      scheduledCalls: [function testFn1(){}, function testFn2(){}]
+      scheduledCalls: {'task1': function testFn1(){}, 'task2': function testFn2(){}}
     });
 
     service.resetRenderState();


### PR DESCRIPTION
- Fixes https://github.com/freshworks/ember-sequential-render/issues/6
- cancel the scheduled calls in `resetRenderState`  to avoid them executing at later point in time with stale states