### PR TITLE
Adding api to accept promise

### DIFF
--- a/addon/components/sequential-render.js
+++ b/addon/components/sequential-render.js
@@ -34,6 +34,7 @@
   @class sequential-render
   @public
   @yield {Hash} hash
+  @yield {Any} hash.content The response from performing getData.
   @yield {boolean} hash.isContentLoading Flag to check the loading state of the data fetch.
   @yield {component} hash.render-content Block component used to render the content of the item.
         Accepts loaderClass as an argument. This class can be used to style the subsequent loading states for the item.  
@@ -243,7 +244,7 @@ export default Component.extend({
         get(this, 'renderStates').addToQueue(renderPriority, taskName);
       }
 
-      if ((asyncRender || get(this, 'getData') || get(this, 'fetchDataTask')) && !renderImmediately) {
+      if ((asyncRender || get(this, 'getData')) && !renderImmediately) {
         get(this, 'fetchData').perform();
       } else {
         this.updateRenderStates();

--- a/addon/components/sequential-render.js
+++ b/addon/components/sequential-render.js
@@ -242,11 +242,22 @@ export default Component.extend({
 
   fetchData: task(function* () {
     let { queryParams, taskOptions } = getProperties(this, 'queryParams', 'taskOptions');
-    let content = yield get(this, 'fetchDataTask').perform(queryParams, taskOptions);
+    let content;
+    if (get(this, 'getData')) {
+      content = yield get(this, 'getData')();
+    } else {
+      content = yield get(this, 'fetchDataTask').perform(queryParams, taskOptions);
+    }
 
     set(this, 'content', content);
-    if (!(isNone(content) && get(this, 'renderPriority') === criticalRender)) {
-      this.updateRenderStates();
+    if (get(this, 'renderCallback')) {
+      if (!(isNone(content) && get(this, 'renderPriority') === criticalRender)) {
+        this.updateRenderStates();
+      }
+    } else {
+      if (get(this, 'renderPriority') === criticalRender) {
+        this.updateRenderStates();
+      }
     }
   }).restartable(),
 

--- a/addon/components/sequential-render.js
+++ b/addon/components/sequential-render.js
@@ -109,10 +109,10 @@ export default Component.extend({
   asyncRender: true,
 
   /**
-    Promise that can be executed to perform the required actions.
+    The function that performs all the required asynchronous actions and returns a promise.
 
     @argument getData
-    @type Promise
+    @type function
     @public
   */
   getData: null,

--- a/tests/dummy/app/controllers/docs/unoptimized.js
+++ b/tests/dummy/app/controllers/docs/unoptimized.js
@@ -1,42 +1,60 @@
 import Controller from '@ember/controller';
-import { task } from 'ember-concurrency';
 import Participants from '../../constants/participants';
 import Notes from '../../constants/notes';
 import SpellWork from '../../constants/spellwork';
 import StaticUrl from '../../constants/static-url';
 import {
-  set
+  set,
+  get
 } from '@ember/object';
 
 export default Controller.extend({
   participantsList: null,
   spellWork: null,
   notes: '',
-  fetchParticipants: task(function* () {
-    let participants = yield fetch(StaticUrl.mockURL500)
-      .then((response) => {
-        return JSON.parse(response).participants;
-      })
-      .catch(() => Participants)
-    set(this, 'participantsList', participants);
-    return participants;
-  }),
-  fetchNotes: task(function* () {
-    let notes = yield fetch(StaticUrl.mockURL200)
-      .then((response) => {
-        return JSON.parse(response).notes;
-      })
-      .catch(() => Notes);
-    set(this, 'notes', notes);
-    return notes;
-  }),
-  fetchSpellWork: task(function* () {
-    let spellWork = yield fetch(StaticUrl.mockURL500)
-      .then((response) => {
-        return JSON.parse(response).spellWork;
-      })
-      .catch(() => SpellWork)
-    set(this, 'spellWork', spellWork);
-    return spellWork;
-  })
+  init() {
+    this._super(...arguments);
+    this.set('getSpellWork', get(this, 'fetchSpellWork').bind(this));
+    this.set('getNotes', get(this, 'fetchNotes').bind(this));
+    this.set('getParticipants', get(this, 'fetchParticipants').bind(this));
+  },
+  fetchParticipants: async function () {
+    let participants;
+    try {
+      let data = await fetch(StaticUrl.mockURL500);
+      participants = JSON.parse(data).notes;
+    } catch (error) {
+      participants = Participants;
+    } finally {
+      set(this, 'participantsList', participants);
+      // eslint-disable-next-line no-unsafe-finally
+      return participants;
+    }
+  },
+  fetchNotes: async function() {
+    let notes;
+    try {
+      let data = await fetch(StaticUrl.mockURL200);
+      notes = JSON.parse(data).notes;
+    } catch (error) {
+      notes = Notes;
+    } finally {
+      set(this, 'notes', notes);
+      // eslint-disable-next-line no-unsafe-finally
+      return notes;
+    }
+  },
+  fetchSpellWork: async function () {
+    let spellWork;
+    try {
+      let data = await fetch(StaticUrl.mockURL500);
+      spellWork = JSON.parse(data).spellWork;
+    } catch (error) {
+      spellWork = SpellWork;
+    } finally {
+      set(this, 'spellWork', spellWork);
+      // eslint-disable-next-line no-unsafe-finally
+      return spellWork;
+    }
+  }
 });

--- a/tests/dummy/app/controllers/docs/unoptimized.js
+++ b/tests/dummy/app/controllers/docs/unoptimized.js
@@ -19,42 +19,30 @@ export default Controller.extend({
     this.set('getParticipants', get(this, 'fetchParticipants').bind(this));
   },
   fetchParticipants: async function () {
-    let participants;
-    try {
-      let data = await fetch(StaticUrl.mockURL500);
-      participants = JSON.parse(data).notes;
-    } catch (error) {
-      participants = Participants;
-    } finally {
-      set(this, 'participantsList', participants);
-      // eslint-disable-next-line no-unsafe-finally
-      return participants;
-    }
+    let participants = await fetch(StaticUrl.mockURL500)
+      .then(response => {
+        return JSON.parse(response).participants
+      })
+      .catch( () =>  Participants);
+    set(this, 'participantsList', participants);
+    return participants;
   },
   fetchNotes: async function() {
-    let notes;
-    try {
-      let data = await fetch(StaticUrl.mockURL200);
-      notes = JSON.parse(data).notes;
-    } catch (error) {
-      notes = Notes;
-    } finally {
-      set(this, 'notes', notes);
-      // eslint-disable-next-line no-unsafe-finally
-      return notes;
-    }
+    let notes = await fetch(StaticUrl.mockURL200)
+      .then(response => {
+        return JSON.parse(response).notes
+      })
+      .catch( () =>  Notes);
+    set(this, 'notes', notes);
+    return notes;
   },
   fetchSpellWork: async function () {
-    let spellWork;
-    try {
-      let data = await fetch(StaticUrl.mockURL500);
-      spellWork = JSON.parse(data).spellWork;
-    } catch (error) {
-      spellWork = SpellWork;
-    } finally {
-      set(this, 'spellWork', spellWork);
-      // eslint-disable-next-line no-unsafe-finally
-      return spellWork;
-    }
+    let spellWork = await fetch(StaticUrl.mockURL500)
+      .then(response => {
+        return JSON.parse(response).spellWork
+      })
+      .catch( () =>  SpellWork);
+    set(this, 'spellWork', spellWork);
+    return spellWork;
   }
 });

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,9 +1,9 @@
 import Controller from '@ember/controller';
-import { task, timeout } from 'ember-concurrency';
+import { timeout } from 'ember-concurrency';
 
 export default Controller.extend({
-  testTaskDelay: task(function* () {
-    yield timeout(2000);
+  testTaskDelay: async function () {
+    await timeout(2000);
     return 'test task';
-  }),
+  }
 });

--- a/tests/dummy/app/routes/docs/unoptimized.js
+++ b/tests/dummy/app/routes/docs/unoptimized.js
@@ -6,9 +6,9 @@ export default Route.extend({
   model() {
     let controller = this.controllerFor('docs.unoptimized');
     return RSVP.hash({
-      spellWork: controller.fetchSpellWork.perform(),
-      participants: controller.fetchParticipants.perform(),
-      notes: controller.fetchNotes.perform()
+      spellWork: controller.fetchSpellWork(),
+      participants: controller.fetchParticipants(),
+      notes: controller.fetchNotes()
     });
   },
   resetController(controller, isExiting) {

--- a/tests/dummy/app/templates/docs/optimized.hbs
+++ b/tests/dummy/app/templates/docs/optimized.hbs
@@ -5,8 +5,8 @@
     <h2 class="maintitle">Dumbledore's Army</h2>
     {{#sequential-render
       renderPriority=0
-      taskName="fetchSpellWork"
-      fetchDataTask=fetchSpellWork as |spellHash|
+      taskName="getSpellWork"
+      getData=getSpellWork as |spellHash|
     }}
       {{#spellHash.render-content}}
         {{#each spellWork as |spell|}}
@@ -32,8 +32,8 @@
       </h4>
       {{#sequential-render
         renderPriority=1
-        taskName="fetchParticipants"
-        fetchDataTask=fetchParticipants as |participantsHash|
+        taskName="getParticipants"
+        getData=getParticipants as |participantsHash|
       }}
         {{#participantsHash.render-content}}
           <div class="element-flex avatarpane">
@@ -56,8 +56,8 @@
       </h4>
       {{#sequential-render
         renderPriority=1
-        taskName="fetchNotes"
-        fetchDataTask=fetchNotes as |notesHash|
+        taskName="getNotes"
+        getData=getNotes as |notesHash|
       }}
         {{#notesHash.render-content}}
           <div class="editor" contenteditable="true">

--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -47,15 +47,15 @@ setupController(controller) {
 
 In this example, the critical or hero element is the content inside the left pane. So that'll be assigned a renderPriority of 0. Subsequently, the quick notes and the participants list will be assigned a renderPriority of 1.
 
-## 4. Wrap the content in sequential-render instances and pass in the required tasks to fetch data
+## 4. Wrap the content in sequential-render instances and pass in the function which performs async operation to get data by returning promise object
 
 ```
 <div class="flex1 schoolroom__mainpanel">
   <h2 class="maintitle">Dumbledore's Army</h2>
   {{#sequential-render
     renderPriority=0
-    taskName="fetchSpellWork"
-    fetchDataTask=fetchSpellWork as |spellHash|
+    taskName="getSpellWork"
+    getData=getSpellWork as |spellHash|
   }}
     {{#spellHash.render-content}}
       {{#each spellWork as |spell|}}
@@ -83,8 +83,8 @@ OR
   <h2 class="maintitle">Dumbledore's Army</h2>
   <sequential-render
     renderPriority={{0}}
-    taskName="fetchSpellWork"
-    fetchDataTask={{fetchSpellWork}} as |spellHash|
+    taskName="getSpellWork"
+    getData={{getSpellWork}} as |spellHash|
   >
     <spellHash.render-content>
       {{#each spellWork as |spell|}}

--- a/tests/dummy/app/templates/docs/usage.md
+++ b/tests/dummy/app/templates/docs/usage.md
@@ -47,7 +47,7 @@ setupController(controller) {
 
 In this example, the critical or hero element is the content inside the left pane. So that'll be assigned a renderPriority of 0. Subsequently, the quick notes and the participants list will be assigned a renderPriority of 1.
 
-## 4. Wrap the content in sequential-render instances and pass in the function which performs async operation to get data by returning promise object
+## 4. Wrap the content in sequential-render instances and pass in a function that returns a promise
 
 ```
 <div class="flex1 schoolroom__mainpanel">

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -27,7 +27,7 @@
     {{#sequential-render
       renderPriority=0
       taskName="priorityZero1"
-      fetchDataTask=testTaskDelay as |renderHash|
+      getData=testTaskDelay as |renderHash|
     }}
       {{#renderHash.render-content}}
         PO ELEMENT
@@ -41,7 +41,7 @@
     {{#sequential-render
       renderPriority=1
       taskName="priorityOne1"
-      fetchDataTask=testTaskDelay as |renderHash|
+      getData=testTaskDelay as |renderHash|
     }}
       {{#renderHash.render-content}}
         P1 ELEMENT

--- a/tests/integration/components/sequential-render-test.js
+++ b/tests/integration/components/sequential-render-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import {timeout} from 'ember-concurrency';
+import { setupOnerror } from '@ember/test-helpers';
 
 module('Integration | Component | sequential-render | ComponentTest', async function(hooks) {
   setupRenderingTest(hooks);
@@ -14,10 +15,12 @@ module('Integration | Component | sequential-render | ComponentTest', async func
       'afterTask1': () => assert.step('first'),
       'afterTask2': () => assert.step('second'),
       'afterTask3': () => assert.step('third'),
-       getDataNoPromise: () => 'test',
        getData: () => new Promise(resolve =>  {
-        setTimeout(resolve(), 2000)
-      }),
+         setTimeout(resolve(), 2000)
+        }),
+       getDataNoPromise: () => 'test',
+       getDataNotFunction: 'test',
+       getDataThrowsError: () => { throw new Error ('myError')},
       fetchDataTask: {
         perform() {
           return function*() {
@@ -27,6 +30,9 @@ module('Integration | Component | sequential-render | ComponentTest', async func
         }
       }
     });
+  });
+  hooks.afterEach(function() {
+    setupOnerror();
   });
 
   test('it renders', async function(assert) {
@@ -195,6 +201,42 @@ module('Integration | Component | sequential-render | ComponentTest', async func
       </SequentialRender>
       `)
       assert.verifySteps(['first', 'third', 'second']);
+  });
+
+  test('Check error is throw when getData is not a function', async function(assert) {
+    setupOnerror(function(err) {
+      assert.equal(err.message, 'Error occured when executing fetchData: TypeError: Ember.get(...) is not a function');
+    });
+    await render(hbs `
+      <SequentialRender
+        @renderPriority={{0}}
+        @taskName="task1"
+        @getData={{this.getDataNotFunction}}
+        as |seq1|
+      >
+      <seq1.RenderContent>
+        <h1>Render Second</h1>
+      </seq1.RenderContent>
+      </SequentialRender>
+      `)
+  });
+
+  test('Check error caught when getData throws some error', async function(assert) {
+    setupOnerror(function(err) {
+      assert.equal(err.message, 'Error occured when executing fetchData: Error: myError');
+    });
+    await render(hbs `
+      <SequentialRender
+        @renderPriority={{0}}
+        @taskName="task1"
+        @getData={{this.getDataThrowsError}}
+        as |seq1|
+      >
+      <seq1.RenderContent>
+        <h1>Render Second</h1>
+      </seq1.RenderContent>
+      </SequentialRender>
+      `)
   });
 
   test('Check order of renders when renderImmediately is used', async function(assert) {

--- a/tests/integration/components/sequential-render-test.js
+++ b/tests/integration/components/sequential-render-test.js
@@ -15,12 +15,12 @@ module('Integration | Component | sequential-render | ComponentTest', async func
       'afterTask1': () => assert.step('first'),
       'afterTask2': () => assert.step('second'),
       'afterTask3': () => assert.step('third'),
-       getData: () => new Promise(resolve =>  {
+      getData: () => new Promise(resolve =>  {
          setTimeout(resolve(), 2000)
         }),
-       getDataNoPromise: () => 'test',
-       getDataNotFunction: 'test',
-       getDataThrowsError: () => { throw new Error ('myError')},
+      getDataNoPromise: () => 'test',
+      getDataNotFunction: 'test',
+      getDataThrowsError: () => { throw new Error ('myError')},
       fetchDataTask: {
         perform() {
           return function*() {

--- a/tests/integration/components/sequential-render-test.js
+++ b/tests/integration/components/sequential-render-test.js
@@ -14,6 +14,9 @@ module('Integration | Component | sequential-render | ComponentTest', async func
       'afterTask1': () => assert.step('first'),
       'afterTask2': () => assert.step('second'),
       'afterTask3': () => assert.step('third'),
+       getData: () => new Promise(resolve =>  {
+        setTimeout(resolve(), 2000)
+      }),
       fetchDataTask: {
         perform() {
           return function*() {
@@ -93,6 +96,45 @@ module('Integration | Component | sequential-render | ComponentTest', async func
         @renderPriority={{1}}
         @taskName="task2"
         @fetchDataTask={{this.fetchDataTask}}
+        @renderCallback={{this.afterTask2}}
+        as |seq1|
+      >
+      <seq1.RenderContent>
+        <h1>Render Second</h1>
+      </seq1.RenderContent>
+      </SequentialRender>
+      <SequentialRender
+        @renderPriority={{1}}
+        @taskName="task3"
+        @asyncRender={{false}}
+        @renderCallback={{this.afterTask3}}
+        as |seq1|
+      >
+      <seq1.RenderContent>
+        <h1>Render Second</h1>
+      </seq1.RenderContent>
+      </SequentialRender>
+      `)
+      assert.verifySteps(['first', 'third', 'second']);
+  });
+
+  test('Check order of execution when an getData parameter which is a promise is present', async function(assert) {
+    await render(hbs `
+      <SequentialRender
+        @renderPriority={{0}}
+        @taskName="Task1"
+        @asyncRender={{false}}
+        @renderCallback={{this.afterTask1}}
+        as |seq|
+      >
+        <seq.RenderContent>
+          <h1>Render Second</h1>
+        </seq.RenderContent>
+      </SequentialRender>
+      <SequentialRender
+        @renderPriority={{1}}
+        @taskName="task2"
+        @getData={{this.getData}}
         @renderCallback={{this.afterTask2}}
         as |seq1|
       >

--- a/tests/integration/components/sequential-render-test.js
+++ b/tests/integration/components/sequential-render-test.js
@@ -14,6 +14,7 @@ module('Integration | Component | sequential-render | ComponentTest', async func
       'afterTask1': () => assert.step('first'),
       'afterTask2': () => assert.step('second'),
       'afterTask3': () => assert.step('third'),
+       getDataNoPromise: () => 'test',
        getData: () => new Promise(resolve =>  {
         setTimeout(resolve(), 2000)
       }),
@@ -157,6 +158,45 @@ module('Integration | Component | sequential-render | ComponentTest', async func
       assert.verifySteps(['first', 'third', 'second']);
   });
 
+  test('Check order of execution when an getData returns non-promise', async function(assert) {
+    await render(hbs `
+      <SequentialRender
+        @renderPriority={{0}}
+        @taskName="Task1"
+        @asyncRender={{false}}
+        @renderCallback={{this.afterTask1}}
+        as |seq|
+      >
+        <seq.RenderContent>
+          <h1>Render Second</h1>
+        </seq.RenderContent>
+      </SequentialRender>
+      <SequentialRender
+        @renderPriority={{1}}
+        @taskName="task2"
+        @getData={{this.getDataNoPromise}}
+        @renderCallback={{this.afterTask2}}
+        as |seq1|
+      >
+      <seq1.RenderContent>
+        <h1>Render Second</h1>
+      </seq1.RenderContent>
+      </SequentialRender>
+      <SequentialRender
+        @renderPriority={{1}}
+        @taskName="task3"
+        @asyncRender={{false}}
+        @renderCallback={{this.afterTask3}}
+        as |seq1|
+      >
+      <seq1.RenderContent>
+        <h1>Render Second</h1>
+      </seq1.RenderContent>
+      </SequentialRender>
+      `)
+      assert.verifySteps(['first', 'third', 'second']);
+  });
+
   test('Check order of renders when renderImmediately is used', async function(assert) {
     await render(hbs `
       <SequentialRender
@@ -251,5 +291,5 @@ module('Integration | Component | sequential-render | ComponentTest', async func
       this.set('triggerOutOfOrder', true);
       await settled();
       assert.verifySteps(['first', 'third', 'second', 'third']);
-  })
+  });
 });


### PR DESCRIPTION
- Expose a new API `getData` that accepts promise, upon successful resolution of the same update we call `updateRenderStates` to increment appState
- The already existing API `fetchDataTask` is very specific to ember tasks, so new API is exposed to accept promise.
- Already existing APIs like `fetchDataTask` `asyncRender` can be removed permanently once this new API is standardised.

- Addresses comment mentioned in https://github.com/freshworks/ember-sequential-render/issues/10
