### PR TITLE
FD-92896-upgrade-follow-redirects

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8183,9 +8183,9 @@ flush-write-stream@^1.0.0:
     readable-stream "^2.3.6"
 
 follow-redirects@^1.0.0:
-  version "1.14.5"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
-  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
https://freshworks.freshrelease.com/ws/FD/tasks/FD-92895
A [known vulnerability](https://github.com/advisories/GHSA-74fj-2j2h-c42q), identified in one of the versions (< 1.14.7) of follow-redirects (NPM) was found in yarn.lock of the repository freshworks/ember-sequential-render.